### PR TITLE
Add initial implementation of lcm-derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 members = [
-  "lcm-gen",
+  "lcm-gen", "lcm-derive"
 ]

--- a/lcm-derive/Cargo.toml
+++ b/lcm-derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lcm-derive"
+version = "0.1.0"
+authors = ["Nathan Kent <nate@nkent.net>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "0.4"
+syn = "0.12"

--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -1,0 +1,100 @@
+extern crate proc_macro;
+extern crate syn;
+
+#[macro_use]
+extern crate quote;
+
+mod parse;
+
+#[proc_macro_derive(LcmMessage, attributes(lcm))]
+pub fn lcm_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
+{
+	let input: syn::DeriveInput = syn::parse(input).unwrap();
+
+	// Parse the fields of the struct.
+	let fields = if let syn::Data::Struct(syn::DataStruct { fields: syn::Fields::Named(ref fields), ..}) = input.data {
+		fields.named.iter().map(|f| parse::Field::from_syn(f)).collect::<Vec<_>>()
+	} else { panic!("LCM only supports structs with named fields.") };
+
+	// Calculate the hash of the struct
+	let hash = calculate_hash(&fields);
+
+	// Get the name of the struct
+	let name = input.ident;
+
+	// Gather the tokens needed for the encode/decode process
+	let encode_tokens = fields.iter().map(|f| f.encode_tokens());
+	let decode_tokens = fields.iter().map(|f| f.decode_tokens());
+	let field_names = fields.iter().map(|f| syn::Ident::from(&f.name as &str));
+	let size_tokens = fields.iter().map(|f| f.size_tokens());
+
+	// Output the implementation
+	let output = quote! {
+		impl ::lcm::Message for #name
+		{
+			const HASH: u64 = #hash;
+
+			fn encode(&self, mut buffer: &mut ::std::io::Write) -> ::std::io::Result<()>
+			{
+				#(#encode_tokens)*
+				Ok(())
+			}
+
+			fn decode(mut buffer: &mut Read) -> Result<Self>
+			{
+				#(#decode_tokens)*
+				Ok(#name {
+					#(#field_names,)*
+				})
+			}
+
+			fn size(&self) -> usize
+			{
+				0
+				#(+ #size_tokens)*
+			}
+		}
+	};
+
+	output.into()
+}
+
+fn calculate_hash(fields: &Vec<parse::Field>) -> u64
+{
+	fn hash_update(v: i64, c: i8) -> i64
+	{
+		((v << 8) ^ (v >> 55)) + c as i64
+	}
+
+	fn hash_string_update(v: i64, s: &[u8]) -> i64
+	{
+		s.iter().fold(hash_update(v, s.len() as i8), |acc, &c| hash_update(acc, c as i8))
+	}
+
+	let mut v = 0x12345678i64;
+
+	for f in fields {
+		// Hash the field name
+		v = hash_string_update(v, f.name.as_bytes());
+
+		// Hash the type information *only* if it is a primitive type
+		if f.base_type.is_primitive_type() {
+			v = hash_string_update(v, f.base_type.as_str().as_bytes());
+		}
+
+		// Hash the dimension information
+		v = hash_update(v, f.dims.len() as i8);
+		for d in f.dims.iter() {
+			// Hash the kind of dimension it was and the value of the dimension
+			v = hash_update(v, d.dim_type());
+			v = hash_string_update(v, d.as_string().as_bytes());
+		}
+	}
+
+	// The following does not happen in the C version of lcmgen. The hash that
+	// version outputs is the current value of `v`. However, we can make this
+	// second step happen during codegen, so why not?
+
+	let v = v as u64;
+	(v << 1) + ((v >> 63) & 1)
+}

--- a/lcm-derive/src/parse.rs
+++ b/lcm-derive/src/parse.rs
@@ -1,0 +1,322 @@
+use quote;
+use syn;
+
+#[derive(Debug)]
+pub struct Field
+{
+	pub name: String,
+	pub base_type: Ty,
+	pub dims: Vec<Dim>,
+}
+impl Field
+{
+	pub fn from_syn(input: &syn::Field) -> Self
+	{
+		// The name is easy but figuring out the base type and the dimensions
+		// is more involved.
+		let base_type = Ty::get_base_type(&input.ty);
+		let dims = Dim::get_dims(&input.ty, &input.attrs);
+
+		Field { name: input.ident.expect("Unnamed field").to_string(), base_type, dims }
+	}
+
+	pub fn encode_tokens(&self) -> quote::Tokens
+	{
+		let name = syn::Ident::from(&self.name as &str);
+
+		// The easiest case are the non-arrays.
+		if self.dims.is_empty() {
+			quote! { ::lcm::Message::encode(&self.#name, &mut buffer)?; }
+		} else {
+			let mut tokens = quote! { ::lcm::Message::encode(&item, &mut buffer)?; };
+			for dim in self.dims.iter().rev() {
+				tokens = match *dim {
+					Dim::Fixed(_) => quote! {for item in item.iter() { #tokens }},
+					Dim::Variable(ref s) => {
+						let size_name = syn::Ident::from(s as &str);
+						quote! {
+							if self.#size_name as usize != item.len() {
+								return Err(::std::io::Error::new(::std::io::ErrorKind::Other, "Size is larger than vector"));
+							}
+							for item in item.iter() { #tokens }
+						}
+					},
+				};
+			}
+
+			quote! {let item = &self.#name; #tokens}
+		}
+	}
+
+	pub fn decode_tokens(&self) -> quote::Tokens
+	{
+		let name = syn::Ident::from(&self.name as &str);
+
+		if self.dims.is_empty() {
+			quote! {let #name = ::lcm::Message::decode(&mut buffer)?; }
+		} else {
+			let mut tokens = quote! { ::lcm::Message::decode(&mut buffer) };
+			let mut need_q_mark = true;
+			for d in self.dims.iter().rev() {
+				tokens = match *d {
+					Dim::Fixed(s) => {
+						let inner = (0..s).map(|_| tokens.clone());
+						let old_q_mark = need_q_mark;
+						need_q_mark = false;
+
+						if old_q_mark {
+							quote! { [ #(#inner?,)* ] }
+						} else {
+							quote! { [ #(#inner,)* ] }
+						}
+					},
+					Dim::Variable(ref s) => {
+						let dim_name = syn::Ident::from(s as &str);
+						need_q_mark = true;
+						quote! { (0..#dim_name).map(|_| #tokens).collect::<Result<_>>() }
+					}
+				};
+			}
+
+			if need_q_mark {
+				quote! { let #name = #tokens?; }
+			} else {
+				quote! { let #name = #tokens; }
+			}
+		}
+	}
+
+	pub fn size_tokens(&self) -> quote::Tokens
+	{
+		// If this isn't a string or a user type, we can make this a constant.
+		match self.base_type {
+			Ty::String | Ty::User(_) => self.size_tokens_nonconst(),
+			_                        => self.size_tokens_const(),
+		}
+	}
+
+	fn size_tokens_const(&self) -> quote::Tokens
+	{
+		let dim_multipliers = self.dims.iter().map(|d| {
+			match *d {
+				Dim::Fixed(s) => quote! { #s },
+				Dim::Variable(ref s) => {
+					let dim_name = syn::Ident::from(s as &str);
+					quote! { self.#dim_name as usize }
+				}
+			}
+		});
+
+		let type_size = self.base_type.size();
+
+		quote!{ (#type_size #(* #dim_multipliers)*) }
+	}
+
+	fn size_tokens_nonconst(&self) -> quote::Tokens
+	{
+		let name = syn::Ident::from(&self.name as &str);
+
+		if self.dims.is_empty() {
+			quote! { ::lcm::Message::size(&self.#name)}
+		} else {
+			let mut tokens = quote! { ::lcm::Message::size(&item) };
+			for _ in self.dims.iter().skip(1).rev() {
+				tokens = quote!{ item.iter().map(|item| #tokens).sum::<usize>() }
+			}
+
+			quote!{ self.#name.iter().map(|item| #tokens).sum::<usize>()}
+		}
+	}
+}
+
+fn get_vec_inner_type(t: &syn::Type) -> &syn::Type
+{
+	let segs = match *t {
+		syn::Type::Path(syn::TypePath { path: syn::Path { ref segments, .. }, ..}) => segments,
+		_ => panic!("Bug: `get_vec_inner_type` called on non-Vec type (1)"),
+	};
+
+	match *segs.iter().last().unwrap() {
+		syn::PathSegment {
+			arguments: syn::PathArguments::AngleBracketed(
+				syn::AngleBracketedGenericArguments { ref args, .. }
+			),
+			..
+		} => {
+			if let syn::GenericArgument::Type(ref ty) = args[0] {
+				ty
+			} else { panic!("Bug: `get_vec_inner_type` called on non-Vec type (2)"); }
+		},
+		_ => panic!("Bug: `get_vec_inner_type` called on non-Vec type (3)")
+	}
+}
+
+#[derive(Clone, Debug)]
+pub enum Ty
+{
+	Int8,
+	Int16,
+	Int32,
+	Int64,
+	Float,
+	Double,
+	String,
+	Boolean,
+	User(String)
+}
+impl Ty
+{
+	pub fn is_primitive_type(&self) -> bool
+	{
+		match *self {
+			Ty::User(_) => false,
+			_           => true
+		}
+	}
+
+	pub fn as_str(&self) -> &str
+	{
+		match *self {
+			Ty::Int8        => "int8_t",
+			Ty::Int16       => "int16_t",
+			Ty::Int32       => "int32_t",
+			Ty::Int64       => "int64_t",
+			Ty::Float       => "float",
+			Ty::Double      => "double",
+			Ty::String      => "string",
+			Ty::Boolean     => "boolean",
+			Ty::User(ref s) => s
+		}
+	}
+
+	fn size(&self) -> usize
+	{
+		match *self {
+			Ty::Int8    => ::std::mem::size_of::<i8>(),
+			Ty::Int16   => ::std::mem::size_of::<i16>(),
+			Ty::Int32   => ::std::mem::size_of::<i32>(),
+			Ty::Int64   => ::std::mem::size_of::<i64>(),
+			Ty::Float   => ::std::mem::size_of::<f32>(),
+			Ty::Double  => ::std::mem::size_of::<f64>(),
+			Ty::Boolean => ::std::mem::size_of::<i8>(),
+			_           => panic!("Tried to get fixed size of non-primitive"),
+		}
+	}
+
+	fn get_base_type(t: &syn::Type) -> Self
+	{
+		// There are two base types allowed here. The `Path` type contains all
+		// of the primitives and `Vec`. The `Array` type is fixed-size arrays.
+		match *t {
+			syn::Type::Path(syn::TypePath { path: syn::Path { ref segments, .. }, .. }) => {
+				// This is either a `Vec` or a primitive
+				match segments.iter().last().unwrap().ident.as_ref() {
+					"i8"     => Ty::Int8,
+					"i16"    => Ty::Int16,
+					"i32"    => Ty::Int32,
+					"i64"    => Ty::Int64,
+					"f32"    => Ty::Float,
+					"f64"    => Ty::Double,
+					"bool"   => Ty::Boolean,
+					"String" => Ty::String,
+					"Vec"    => Ty::get_base_type(get_vec_inner_type(t)),
+					n @ _    => Ty::User(n.to_string()),
+				}
+			},
+			syn::Type::Array(syn::TypeArray { ref elem, ..}) => {
+				// This is an array. Go a level deeper to figure out the base type
+				Ty::get_base_type(elem.as_ref())
+			},
+			_ => panic!("Type must either be an LCM primitive or an array"),
+		}
+	}
+}
+
+#[derive(Debug)]
+pub enum Dim
+{
+	Fixed(usize),
+	Variable(String),
+}
+impl Dim
+{
+	pub fn dim_type(&self) -> i8
+	{
+		match *self {
+			Dim::Fixed(_)    => 0,
+			Dim::Variable(_) => 1,
+		}
+	}
+
+	pub fn as_string(&self) -> String
+	{
+		match *self {
+			Dim::Fixed(s)        => format!("{}", s),
+			Dim::Variable(ref s) => s.clone(),
+		}
+	}
+
+	fn get_dims(t: &syn::Type, attrs: &Vec<syn::Attribute>) -> Vec<Self>
+	{
+		let mut res = Vec::new();
+		let mut vec_dims = Dim::get_vec_dims(attrs);
+		Dim::get_dims_internal(t, &mut vec_dims, &mut res);
+
+		assert!(vec_dims.is_empty(), "Too many vector dimensions specified");
+
+		res
+	}
+
+	fn get_dims_internal(t: &syn::Type, vec_dims: &mut Vec<Self>, res: &mut Vec<Self>)
+	{
+		match *t {
+			syn::Type::Path(syn::TypePath { path: syn::Path { ref segments, .. }, .. }) => {
+				match segments.iter().last().unwrap().ident.as_ref() {
+					"Vec" => {
+						res.push(vec_dims.pop().expect("Missing size for variable length array"));
+						Dim::get_dims_internal(get_vec_inner_type(t), vec_dims, res);
+					},
+					_     => { /* lcmgen (C version) does not store this info */},
+				}
+			},
+			syn::Type::Array(syn::TypeArray { ref elem, len: syn::Expr::Lit(syn::ExprLit{ lit: syn::Lit::Int(ref lit), ..}), ..}) => {
+				res.push(Dim::Fixed(lit.value() as usize));
+				Dim::get_dims_internal(elem.as_ref(), vec_dims, res);
+			},
+			_ => panic!("Type must either be an LCM primitive or an array"),
+		}
+	}
+
+	fn get_vec_dims(attrs: &Vec<syn::Attribute>) -> Vec<Self>
+	{
+		let mut sizes = Vec::new();
+
+		for a in attrs {
+			match a.interpret_meta() {
+				Some(syn::Meta::List(ref meta_list)) if meta_list.ident.as_ref() == "lcm" => {
+					// This is an `lcm(...)` attribute
+					for n in meta_list.nested.iter() {
+						match *n {
+							syn::NestedMeta::Meta(
+								syn::Meta::NameValue(
+									syn::MetaNameValue {
+										ref ident,
+										lit: syn::Lit::Str(ref var_name),
+										..
+									}
+								)
+							) if ident.as_ref() == "length" => {
+								// This is a length attribute
+								sizes.push(Dim::Variable(var_name.value()));
+							},
+							_ => {},
+						}
+					}
+				},
+				_ => {},
+			}
+		}
+
+		sizes
+	}
+}


### PR DESCRIPTION
This is an initial implementation of the `lcm-derive` procedural macro. The code is very messy partially because `syn` is a bit of a mess and partially because I wanted to get this implemented as quickly as possible. As such, there is significant room for improvement.

That being said, I've done a little bit of testing (including combinations of multidimensional arrays with variable and fixed sizes) and they all appear to output something sane. Additionally, the output is based on the current definition of `lcm::Message` with one exception: `Message::HASH` is now an associated constant rather than a function call.

The following is the output from the `exlcm.example_t` message (formatting and comments added by hand for ease of reading):

```rust
#[derive(LcmMessage)]
struct Example {
    timestamp: i64,
    position: [f64; 3],
    orientation: [f64; 4],
    num_ranges: i32,

    #[lcm(length = "num_ranges")]
    ranges: Vec<i16>,

    name: String,
    enabled: bool,
}

// Everything below here is generated by the proc macro
impl ::lcm::Message for Example {
    const HASH: u64 = 3987159373929993494u64;

    fn encode(&self, mut buffer: &mut ::std::io::Write) -> ::std::io::Result<()> {
        // Encode `timestamp`
        ::lcm::Message::encode(&self.timestamp, &mut buffer)?;

        // Encode `position`
        let item = &self.position;
        for item in item.iter() {
            ::lcm::Message::encode(&item, &mut buffer)?;
        }

        // Encode `orientation`
        let item = &self.orientation;
        for item in item.iter() {
            ::lcm::Message::encode(&item, &mut buffer)?;
        }

        // Encode `num_ranges`
        ::lcm::Message::encode(&self.num_ranges, &mut buffer)?;

        // Encode `ranges`
        let item = &self.ranges;
        if self.num_ranges as usize != item.len() {
            return Err(::std::io::Error::new(::std::io::ErrorKind::Other,
                                             "Size is larger than vector"));
        }
        for item in item.iter() {
            ::lcm::Message::encode(&item, &mut buffer)?;
        }

        // Encode `name`
        ::lcm::Message::encode(&self.name, &mut buffer)?;

        // Encode `enabled`
        ::lcm::Message::encode(&self.enabled, &mut buffer)?;
        Ok(())
    }
    fn decode(mut buffer: &mut ::std::io::Read) -> Result<Self> {
        let timestamp = ::lcm::Message::decode(&mut buffer)?;
        let position =
            [::lcm::Message::decode(&mut buffer)?,
             ::lcm::Message::decode(&mut buffer)?,
             ::lcm::Message::decode(&mut buffer)?];
        let orientation =
            [::lcm::Message::decode(&mut buffer)?,
             ::lcm::Message::decode(&mut buffer)?,
             ::lcm::Message::decode(&mut buffer)?,
             ::lcm::Message::decode(&mut buffer)?];
        let num_ranges = ::lcm::Message::decode(&mut buffer)?;
        let ranges =
            (0..num_ranges).map(|_| ::lcm::Message::decode(&mut buffer))
                           .collect::<Result<_>>()?;
        let name = ::lcm::Message::decode(&mut buffer)?;
        let enabled = ::lcm::Message::decode(&mut buffer)?;
        Ok(Example{timestamp,
                   position,
                   orientation,
                   num_ranges,
                   ranges,
                   name,
                   enabled,})
    }
    fn size(&self) -> usize {
        0
        + (8usize)                            // timestamp
        + (8usize * 3usize)                   // position
        + (8usize * 4usize)                   // orientation
        + (4usize)                            // num_ranges
        + (2usize * self.num_ranges as usize) // ranges
        + ::lcm::Message::size(&self.name)    // name
        + (1usize)                            // enabled
    }
}
```

## Hashes

~~The resulting hash is the same as the hash that `lcmgen` outputs and then ran through the `(hash << 1) + ((hash >> 63) & 1)` that exists in the current implementation of `lcm::Message`.~~ The code for `lcmgen` specifically says that they do not hash the names of non-primitive data types so I do not see us needing a way to specify struct name and package.

I was comparing against the Rust output of lcmgen from the other repo. See [this comment](https://github.com/adeschamps/lcm-rust/pull/2#issuecomment-366869308).

##  Variable length arrays

The size of variable length arrays are determined by the `#[lcm(length = "var")]` attribute. If there are multiple dimensions are variable length then they are specified using `#[lcm(length = "var0", length = "var1", ...)]` with the specified lengths going from outer-most to inner-most variable length array. The macro does check to make sure the number of specified lengths matches the number of variable dimensions.

E.g.,
```rust
#[derive(LcmMessage)]
struct Image {
    height: i32,
    width: i32,

    #[lcm(length = "height", length = "width")]
    data: Vec<Vec<[u8; 3]>>, // data: [[[u8; 3]; width]; height],

    #[lcm(length = "height", length = "width")]
    equally_valid_data: Vec<[Vec<u8>; 3]>, // data: [[[u8; width]; 3]; height],
}
```

There is room for improvement with that interface, but it works.

## Size calculation

If the size calculation can be done at generation, the macro will do so. This means that any field whose base type is *not* a string and *not* a user-defined type will not require a function call to calculate the size. If the field additionally does not include any variable length arrays, the size can be fully calculated at compile time.

This is probably a pointless optimization but it was easy to do. I also think it would be cool if we could beat the C version of LCM in a benchmark test, since speed is one of the major selling points of LCM.

## Potential bugs

This has not been thoroughly tested. One potential bug that I've noticed is that the macro does nothing to enforce the variable length array coming after the specified size variable. I *think* this will be caught as a compiler error in the `Message::decode` function (since a variable won't be defined) but I have not checked this to be the case.

The hash generation is actually not correct for types composed of other user defined types. See [this comment](https://github.com/adeschamps/lcm-rust/pull/2#issuecomment-366869308).

I have not tried to compile the resulting code. Aside from a potential borrowck issue in the `Message::decode` function (mutable borrow in the `map`, but this is just a NLL thing), I don't see anywhere it should fail.

## Other

Feel free to reformat the code in this commit before merging, as my preferred style is not Rust standard.