### PR TITLE
Begin adding tests for custom derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
 members = [
-  "lcm-gen", "lcm-derive"
+  "lcm",
+  "lcm-gen",
+  "lcm-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
   "lcm",
   "lcm-gen",
   "lcm-derive",
+  "tests",
 ]

--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -7,7 +7,7 @@ extern crate quote;
 mod parse;
 
 /// Entry point of the procedural macro.
-#[proc_macro_derive(LcmMessage, attributes(lcm))]
+#[proc_macro_derive(Message, attributes(lcm))]
 pub fn lcm_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 {
 	let input: syn::DeriveInput = syn::parse(input).unwrap();

--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -50,7 +50,7 @@ pub fn lcm_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 				Ok(())
 			}
 
-			fn decode(mut buffer: &mut ::std::io::Read) -> Result<Self>
+			fn decode(mut buffer: &mut ::std::io::Read) -> ::std::io::Result<Self>
 			{
 				#(#decode_tokens)*
 				Ok(#name {

--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -43,7 +43,10 @@ pub fn lcm_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 				const PRE_HASH: u64 = #hash #(+ <#hash_included_fields as ::lcm::Message>::HASH)*;
 				(PRE_HASH << 1) + ((PRE_HASH >> 63) & 1)
 			};
+        }
 
+        impl ::lcm::Marshall for #name
+        {
 			fn encode(&self, mut buffer: &mut ::std::io::Write) -> ::std::io::Result<()>
 			{
 				#(#encode_tokens)*

--- a/lcm-derive/src/parse.rs
+++ b/lcm-derive/src/parse.rs
@@ -45,7 +45,7 @@ impl Field
 		if self.dims.is_empty() {
 			quote! { ::lcm::Message::encode(&self.#name, &mut buffer)?; }
 		} else {
-			let mut tokens = quote! { ::lcm::Message::encode(&item, &mut buffer)?; };
+			let mut tokens = quote! { ::lcm::Message::encode(item, &mut buffer)?; };
 			for dim in self.dims.iter().rev() {
 				tokens = match *dim {
 					Dim::Fixed(_) => quote! {for item in item.iter() { #tokens }},
@@ -85,7 +85,7 @@ impl Field
 						need_q_mark = false;
 
 						if old_q_mark {
-							quote! { [ #(#inner?,)* ] }
+							quote! { Ok([ #(#inner?,)* ]) }
 						} else {
 							quote! { [ #(#inner,)* ] }
 						}
@@ -93,7 +93,7 @@ impl Field
 					Dim::Variable(ref s) => {
 						let dim_name = syn::Ident::from(s as &str);
 						need_q_mark = true;
-						quote! { (0..#dim_name).map(|_| #tokens).collect::<Result<_>>() }
+						quote! { (0..#dim_name).map(|_| #tokens).collect::<Result<_, ::std::io::Error>>() }
 					}
 				};
 			}

--- a/lcm-derive/src/parse.rs
+++ b/lcm-derive/src/parse.rs
@@ -43,9 +43,9 @@ impl Field
 
 		// The easiest case are the non-arrays.
 		if self.dims.is_empty() {
-			quote! { ::lcm::Message::encode(&self.#name, &mut buffer)?; }
+			quote! { ::lcm::Marshall::encode(&self.#name, &mut buffer)?; }
 		} else {
-			let mut tokens = quote! { ::lcm::Message::encode(item, &mut buffer)?; };
+			let mut tokens = quote! { ::lcm::Marshall::encode(item, &mut buffer)?; };
 			for dim in self.dims.iter().rev() {
 				tokens = match *dim {
 					Dim::Fixed(_) => quote! {for item in item.iter() { #tokens }},
@@ -73,9 +73,9 @@ impl Field
 		let name = self.name;
 
 		if self.dims.is_empty() {
-			quote! {let #name = ::lcm::Message::decode(&mut buffer)?; }
+			quote! {let #name = ::lcm::Marshall::decode(&mut buffer)?; }
 		} else {
-			let mut tokens = quote! { ::lcm::Message::decode(&mut buffer) };
+			let mut tokens = quote! { ::lcm::Marshall::decode(&mut buffer) };
 			let mut need_q_mark = true;
 			for d in self.dims.iter().rev() {
 				tokens = match *d {
@@ -152,9 +152,9 @@ impl Field
 		let name = self.name;
 
 		if self.dims.is_empty() {
-			quote! { ::lcm::Message::size(&self.#name)}
+			quote! { ::lcm::Marshall::size(&self.#name)}
 		} else {
-			let mut tokens = quote! { ::lcm::Message::size(&item) };
+			let mut tokens = quote! { ::lcm::Marshall::size(&item) };
 			for _ in self.dims.iter().skip(1).rev() {
 				tokens = quote!{ item.iter().map(|item| #tokens).sum::<usize>() }
 			}

--- a/lcm-gen/src/codegen.rs
+++ b/lcm-gen/src/codegen.rs
@@ -103,12 +103,12 @@ impl<'a> CodeGenerator<'a> {
             let lengths = field
                 .multiplicity
                 .iter()
-                .map(|mult| match *mult {
-                    ast::Multiplicity::Constant(len) => len.to_string(),
-                    ast::Multiplicity::Variable(ref len) => len.to_string(),
+                .filter_map(|mult| match *mult {
+                    ast::Multiplicity::Constant(_) => None,
+                    ast::Multiplicity::Variable(ref len) => Some(format!("length = \"{}\"", len))
                 })
-                .join("; ");
-            self.push_line(&format!("#[lcm(length = \"{}\")]", lengths));
+                .join(", ");
+            self.push_line(&format!("#[lcm({})]", lengths));
         }
         self.push(&format!("pub {}: ", field.name));
         for multiplicity in &field.multiplicity {

--- a/lcm-gen/src/codegen.rs
+++ b/lcm-gen/src/codegen.rs
@@ -79,7 +79,7 @@ impl<'a> CodeGenerator<'a> {
         if let Some(ref comment) = s.comment {
             self.generate_comment(comment);
         }
-        self.push_line("#[derive(Debug, LcmMessage)]");
+        self.push_line("#[derive(Debug, Message)]");
         self.push_line(&format!("pub struct {} {{", s.name));
         for field in &s.fields {
             self.indent().generate_field(field);

--- a/lcm-gen/src/codegen.rs
+++ b/lcm-gen/src/codegen.rs
@@ -140,13 +140,13 @@ impl<'a> CodeGenerator<'a> {
             self.generate_comment(comment);
         }
         self.push_line(&format!(
-            "const {}: {} = {};",
+            "pub const {}: {} = {};",
             constant.name, constant.ty, constant.value
         ));
     }
 
     fn generate_comment(&mut self, comment: &ast::Comment) {
-        self.push_line(&format!("#[doc = \"{}\"]", comment.0));
+        self.push_line(&format!("#[doc = r#\"{}\"#]", comment.0));
     }
 }
 

--- a/lcm-gen/tests/codegen.rs
+++ b/lcm-gen/tests/codegen.rs
@@ -66,16 +66,16 @@ check_generated!(
 
 check_generated!(
     comments_t,
-    r#"#[doc = " This is a comment
- that spans multiple lines"]
+    r##"#[doc = r#" This is a comment
+ that spans multiple lines"#]
 #[derive(Debug, Message)]
 pub struct my_struct_t {
-    #[doc = " Horizontal position in meters."]
+    #[doc = r#" Horizontal position in meters."#]
     pub x: i32,
-    #[doc = " Vertical position in meters."]
+    #[doc = r#" Vertical position in meters."#]
     pub y: i32,
 }
-"#
+"##
 );
 
 check_generated!(
@@ -98,16 +98,16 @@ pub struct C {
 
 check_generated!(
     my_constants_t,
-    r#"#[derive(Debug, Message)]
+    r##"#[derive(Debug, Message)]
 pub struct my_constants_t {
 }
 impl my_constants_t {
-    const YELLOW: i32 = 1;
-    const GOLDENROD: i32 = 2;
-    const CANARY: i32 = 3;
-    const E: f64 = 2.8718;
+    pub const YELLOW: i32 = 1;
+    pub const GOLDENROD: i32 = 2;
+    pub const CANARY: i32 = 3;
+    pub const E: f64 = 2.8718;
 }
-"#
+"##
 );
 
 check_generated!(
@@ -123,17 +123,17 @@ pub struct point2d_list_t {
 
 check_generated!(
     temperature_t,
-    r#"#[derive(Debug, Message)]
+    r##"#[derive(Debug, Message)]
 pub struct temperature_t {
     pub utime: i64,
-    #[doc = " Temperature in degrees Celsius. A "float" would probably
+    #[doc = r#" Temperature in degrees Celsius. A "float" would probably
      * be good enough, unless we're measuring temperatures during
      * the big bang. Note that the asterisk on the beginning of this
      * line is not syntactically necessary, it's just pretty.
-     "]
+     "#]
     pub degCelsius: f64,
 }
-"#
+"##
 );
 
 /// Tests the case where multiple members share the same type:
@@ -143,14 +143,14 @@ pub struct temperature_t {
 /// ```
 check_generated!(
     member_group,
-    r#"#[derive(Debug, Message)]
+    r##"#[derive(Debug, Message)]
 pub struct member_group {
-    #[doc = " A vector."]
+    #[doc = r#" A vector."#]
     pub x: f64,
-    #[doc = " A vector."]
+    #[doc = r#" A vector."#]
     pub y: f64,
-    #[doc = " A vector."]
+    #[doc = r#" A vector."#]
     pub z: f64,
 }
-"#
+"##
 );

--- a/lcm-gen/tests/codegen.rs
+++ b/lcm-gen/tests/codegen.rs
@@ -115,7 +115,7 @@ check_generated!(
     r#"#[derive(Debug, Message)]
 pub struct point2d_list_t {
     pub npoints: i32,
-    #[lcm(length = "npoints; 2")]
+    #[lcm(length = "npoints")]
     pub points: Vec<[f64; 2]>,
 }
 "#

--- a/lcm-gen/tests/codegen.rs
+++ b/lcm-gen/tests/codegen.rs
@@ -28,7 +28,7 @@ fn simple_struct() {
 
     let generated = codegen::generate(&module);
 
-    let expected = r#"#[derive(Debug, LcmMessage)]
+    let expected = r#"#[derive(Debug, Message)]
 pub struct MyType {
     pub field: f64,
 }
@@ -53,7 +53,7 @@ macro_rules! check_generated {
 check_generated!(
     camera_image_t,
     r#"pub mod mycorp {
-    #[derive(Debug, LcmMessage)]
+    #[derive(Debug, Message)]
     pub struct camera_image_t {
         pub utime: i64,
         pub camera_name: String,
@@ -68,7 +68,7 @@ check_generated!(
     comments_t,
     r#"#[doc = " This is a comment
  that spans multiple lines"]
-#[derive(Debug, LcmMessage)]
+#[derive(Debug, Message)]
 pub struct my_struct_t {
     #[doc = " Horizontal position in meters."]
     pub x: i32,
@@ -80,16 +80,16 @@ pub struct my_struct_t {
 
 check_generated!(
     multiple_structs,
-    r#"#[derive(Debug, LcmMessage)]
+    r#"#[derive(Debug, Message)]
 pub struct A {
     pub b: B,
     pub c: C,
 }
-#[derive(Debug, LcmMessage)]
+#[derive(Debug, Message)]
 pub struct B {
     pub a: A,
 }
-#[derive(Debug, LcmMessage)]
+#[derive(Debug, Message)]
 pub struct C {
     pub b: B,
 }
@@ -98,7 +98,7 @@ pub struct C {
 
 check_generated!(
     my_constants_t,
-    r#"#[derive(Debug, LcmMessage)]
+    r#"#[derive(Debug, Message)]
 pub struct my_constants_t {
 }
 impl my_constants_t {
@@ -112,7 +112,7 @@ impl my_constants_t {
 
 check_generated!(
     point2d_list_t,
-    r#"#[derive(Debug, LcmMessage)]
+    r#"#[derive(Debug, Message)]
 pub struct point2d_list_t {
     pub npoints: i32,
     #[lcm(length = "npoints; 2")]
@@ -123,7 +123,7 @@ pub struct point2d_list_t {
 
 check_generated!(
     temperature_t,
-    r#"#[derive(Debug, LcmMessage)]
+    r#"#[derive(Debug, Message)]
 pub struct temperature_t {
     pub utime: i64,
     #[doc = " Temperature in degrees Celsius. A "float" would probably
@@ -143,7 +143,7 @@ pub struct temperature_t {
 /// ```
 check_generated!(
     member_group,
-    r#"#[derive(Debug, LcmMessage)]
+    r#"#[derive(Debug, Message)]
 pub struct member_group {
     #[doc = " A vector."]
     pub x: f64,

--- a/lcm/Cargo.toml
+++ b/lcm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "lcm"
+version = "0.1.0"
+authors = ["Anthony Deschamps <anthony.j.deschamps@gmail.com>"]
+
+[dependencies]
+byteorder = "1.2.1"

--- a/lcm/src/lib.rs
+++ b/lcm/src/lib.rs
@@ -1,0 +1,163 @@
+//! This is just a placeholder for the actual implementation of
+//! LCM. It just contains the `Message` trait, so that tests can
+//! compile.
+
+extern crate byteorder;
+
+use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
+use std::io::{self, Read, Write};
+
+/// A message that can be encoded and decoded according to the LCM protocol.
+pub trait Message: Sized {
+    /// Returns the message hash for this type.
+    /// Returns `0` for all primitive types.
+    /// Generated `Lcm` types should implement this function.
+    const HASH: u64;
+
+    /// Encodes a message into a buffer, with the message hash at the beginning.
+    fn encode_with_hash(&self) -> io::Result<Vec<u8>> {
+        let size = Self::HASH.size() + self.size();
+        let mut buffer = Vec::with_capacity(size);
+        Self::HASH.encode(&mut buffer)?;
+        self.encode(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    /// Decodes a message from a buffer,
+    /// and also checks that the hash at the beginning is correct.
+    fn decode_with_hash(mut buffer: &mut Read) -> io::Result<Self> {
+        let hash: u64 = Message::decode(&mut buffer)?;
+        if hash != Self::HASH {
+            return Err(io::Error::new(io::ErrorKind::Other, "Invalid hash"));
+        }
+        Message::decode(buffer)
+    }
+
+    /// Encodes a message into a buffer.
+    /// `Lcm` uses a `Vec<u8>` with its capacity set to the value returned by [`size()`].
+    fn encode(&self, buffer: &mut Write) -> io::Result<()>;
+
+    /// Decodes a message from a buffer.
+    fn decode(buffer: &mut Read) -> io::Result<Self>;
+
+    /// Returns the number of bytes this message is expected to take when encoded.
+    fn size(&self) -> usize;
+}
+
+macro_rules! impl_message {
+    ( $type:ty, $read:ident, $write:ident $(, $endian:ident )* ) => {
+        impl Message for $type {
+            const HASH: u64 = 0;
+
+            fn encode(&self, buffer: &mut Write) -> io::Result<()> {
+                buffer.$write::<$($endian),*>(*self)
+            }
+
+            fn decode(buffer: &mut Read) -> io::Result<Self> {
+                buffer.$read::<$($endian),*>()
+            }
+
+            fn size(&self) -> usize {
+                ::std::mem::size_of::<$type>()
+            }
+        }
+    };
+}
+
+impl_message!(u8, read_u8, write_u8);
+impl_message!(u64, read_u64, write_u64, NetworkEndian);
+
+impl_message!(i8, read_i8, write_i8);
+impl_message!(i16, read_i16, write_i16, NetworkEndian);
+impl_message!(i32, read_i32, write_i32, NetworkEndian);
+impl_message!(i64, read_i64, write_i64, NetworkEndian);
+
+impl_message!(f32, read_f32, write_f32, NetworkEndian);
+impl_message!(f64, read_f64, write_f64, NetworkEndian);
+
+impl Message for bool {
+    const HASH: u64 = 0;
+
+    fn encode(&self, buffer: &mut Write) -> io::Result<()> {
+        let value: i8 = if *self { 1 } else { 0 };
+        value.encode(buffer)
+    }
+
+    fn decode(buffer: &mut Read) -> io::Result<Self> {
+        let value = i8::decode(buffer)?;
+        match value {
+            0 => Ok(false),
+            1 => Ok(true),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Booleans should be encoded as 0 or 1",
+            )),
+        }
+    }
+
+    fn size(&self) -> usize {
+        ::std::mem::size_of::<i8>()
+    }
+}
+
+impl Message for String {
+    const HASH: u64 = 0;
+
+    fn encode(&self, buffer: &mut Write) -> io::Result<()> {
+        let len: i32 = self.len() as i32 + 1;
+        len.encode(buffer)?;
+        for &b in self.as_bytes() {
+            b.encode(buffer)?;
+        }
+        (0 as u8).encode(buffer)
+    }
+
+    fn decode(buffer: &mut Read) -> io::Result<Self> {
+        // Until fallable allocation is stable, we can't use
+        // Vec::with_capacity because an invalid input could cause a
+        // panic.
+
+        let len = i32::decode(buffer)?;
+        if len <= 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Attempting to decode a string with an invalid size.",
+            ));
+        }
+        let len = len - 1;
+        let mut buf = Vec::new();
+        for _ in 0..len {
+            buf.push(u8::decode(buffer)?);
+        }
+        let result = String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        match buffer.read_u8() {
+            Ok(0) => Ok(result),
+            Ok(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Expected null terminator",
+            )),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn size(&self) -> usize {
+        ::std::mem::size_of::<i32>() + self.len() + 1
+    }
+}
+
+#[test]
+fn decode_string() {
+    let s: String = "Hello, world!".into();
+    let mut buffer = Vec::new();
+    s.encode(&mut buffer).unwrap();
+
+    let decoded = String::decode(&mut buffer.as_slice()).unwrap();
+    assert_eq!(decoded, "Hello, world!");
+}
+
+#[test]
+fn decode_null_string() {
+    let mut buffer: &[u8] = &[255, 0, 0, 0];
+    let decoded = String::decode(&mut buffer);
+    assert!(decoded.is_err());
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tests"
+version = "0.1.0"
+authors = ["Anthony Deschamps <anthony.j.deschamps@gmail.com>"]
+build = "src/build.rs"
+publish = false
+
+[lib]
+doctest = false
+
+[dependencies]
+lcm = { path = "../lcm" }
+lcm-derive = { path = "../lcm-derive" }
+
+[build-dependencies]
+lcm-gen = { path = "../lcm-gen" }
+glob = "0.2.11"

--- a/tests/lcm/comments_t.lcm
+++ b/tests/lcm/comments_t.lcm
@@ -1,0 +1,10 @@
+// This is a comment that is not part of the struct.
+
+// This is a comment
+// that spans multiple lines
+struct my_struct_t {
+    // Horizontal position in meters.
+    int32_t x;
+    // Vertical position in meters.
+    int32_t y;
+}

--- a/tests/lcm/member_group.lcm
+++ b/tests/lcm/member_group.lcm
@@ -1,0 +1,4 @@
+struct member_group {
+    // A vector.
+    double x, y, z;
+}

--- a/tests/lcm/my_constants_t.lcm
+++ b/tests/lcm/my_constants_t.lcm
@@ -1,0 +1,5 @@
+struct my_constants_t
+{
+    const int32_t YELLOW=1, GOLDENROD=2, CANARY=3;
+    const double E=2.8718;
+}

--- a/tests/lcm/point2d_list_t.lcm
+++ b/tests/lcm/point2d_list_t.lcm
@@ -1,0 +1,5 @@
+struct point2d_list_t
+{
+    int32_t npoints;
+    double  points[npoints][2];
+}

--- a/tests/lcm/temperature_t.lcm
+++ b/tests/lcm/temperature_t.lcm
@@ -1,0 +1,11 @@
+struct temperature_t
+{
+    int64_t   utime;         // Timestamp, in microseconds
+
+    /* Temperature in degrees Celsius. A "float" would probably
+     * be good enough, unless we're measuring temperatures during
+     * the big bang. Note that the asterisk on the beginning of this
+     * line is not syntactically necessary, it's just pretty.
+     */
+    double    degCelsius;
+}

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -1,0 +1,11 @@
+extern crate glob;
+extern crate lcm_gen;
+
+fn main() {
+    let files: Vec<_> = glob::glob("lcm/*.lcm")
+        .expect("Failed to find LCM files")
+        .filter_map(Result::ok)
+        .collect();
+
+    lcm_gen::generate(&files).expect("Failed to generate bindings for LCM types");
+}

--- a/tests/src/hashes.rs
+++ b/tests/src/hashes.rs
@@ -2,5 +2,11 @@ use lcm::Message;
 
 #[test]
 fn hashes() {
+    // Expected hash values were generated manually from the C
+    // implementation of lcm-gen.
+    assert_eq!(::member_group::HASH, 0xae7e5fba5eeca11e);
+    assert_eq!(::my_constants_t::HASH, 0x000000002468acf0);
+    assert_eq!(::my_struct_t::HASH, 0x4fab8e09620e9ec9);
+    assert_eq!(::point2d_list_t::HASH, 0x4f85d1e7da2fc594);
     assert_eq!(::temperature_t::HASH, 0xa07fa3d64cbea6ea);
 }

--- a/tests/src/hashes.rs
+++ b/tests/src/hashes.rs
@@ -1,0 +1,6 @@
+use lcm::Message;
+
+#[test]
+fn hashes() {
+    assert_eq!(::temperature_t::HASH, 0xa07fa3d64cbea6ea);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,10 @@
+#![allow(unused_variables, unused_mut, non_camel_case_types, non_snake_case)]
+
+extern crate lcm;
+#[macro_use]
+extern crate lcm_derive;
+
+include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+
+#[cfg(test)]
+mod hashes;


### PR DESCRIPTION
I added an `lcm` crate which contains only the definition of the `Message` trait. It was mostly copied from the other repo, with a few changes.

This is so that the other crate I added, `tests`, can compile. This crate is meant for testing generated code and any other integration tests.

Along the way, I fixed a few small things, such as outputting raw strings for documentation items (so that quotes don't cause an issue) and making associated consts public.