### PR TITLE
Handle qualified types and generics

### DIFF
--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -84,9 +84,7 @@ fn check_length_variables(fields: &Vec<parse::Field>)
 	                 .filter_map(|(e, d)| match *d { parse::Dim::Variable(ref s) => Some((e, s)), _ => None});
 
 	for (p, length_variable_name) in dims {
-		if p == 0 { panic!("Length variable must appear before array which uses it."); }
-
-		let length_field = fields.iter().take(p - 1)
+		let length_field = fields.iter().take(p)
 		                         .find(|f| f.name.as_ref() == length_variable_name)
 		                         .expect("Length variable must appear before array which uses it.");
 

--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -21,7 +21,8 @@ pub fn lcm_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 	let hash = calculate_hash(&fields);
 	let hash_included_fields = fields.iter().filter_map(|f| {
 		match f.base_type {
-			parse::Ty::User(ref s) => Some(syn::Ident::from(s as &str)),
+			//parse::Ty::User(ref s) => Some(syn::Ident::from(s as &str)),
+			parse::Ty::User(ref s) => Some(syn::parse_str::<syn::Expr>(s).expect("Failed to parse field name")),
 			_                      => None,
 		}
 	});

--- a/lcm-derive/src/lib.rs
+++ b/lcm-derive/src/lib.rs
@@ -24,7 +24,6 @@ pub fn lcm_message(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 	let hash = calculate_hash(&fields);
 	let hash_included_fields = fields.iter().filter_map(|f| {
 		match f.base_type {
-			//parse::Ty::User(ref s) => Some(syn::Ident::from(s as &str)),
 			parse::Ty::User(ref s) => Some(syn::parse_str::<syn::Expr>(s).expect("Failed to parse field name")),
 			_                      => None,
 		}


### PR DESCRIPTION
Qualified types (e.g., "some_mod::Foo") and generics are now correctly handled in the derive output.

Other notes:
* I decided that we won't / can't support situations where the user has their own types named `String`, `Vec`, or any of the primitives. At code generation, there is no way to determine if `Vec` really is a `std::vec::Vec` so we have to assume that it is.
* The length variable for arrays now has to be an integer type and has to be declared before the array that uses it.