### PR TITLE
Improved error handling

### DIFF
--- a/lcm-derive/src/parse.rs
+++ b/lcm-derive/src/parse.rs
@@ -54,7 +54,7 @@ impl Field {
                         quote! {
                             if self.#size_name as usize != item.len() {
                                 return Err(::lcm::error::EncodeError::SizeMismatch {
-                                    size_var: stringify!(#size_name).into(),
+                                    size_var: stringify!(#size_name),
                                     expected: self.#size_name as i64,
                                     found: item.len()
                                 });

--- a/lcm/src/error.rs
+++ b/lcm/src/error.rs
@@ -217,36 +217,43 @@ pub mod from {
     use std::sync::mpsc;
     use super::*;
 
+    #[doc(hidden)]
     impl From<io::Error> for InitError {
         fn from(err: io::Error) -> Self {
             InitError::IoError(err)
         }
     }
+    #[doc(hidden)]
     impl From<regex::Error> for SubscribeError {
         fn from(err: regex::Error) -> Self {
             SubscribeError::InvalidRegex(err)
         }
     }
+    #[doc(hidden)]
     impl From<EncodeError> for PublishError {
         fn from(err: EncodeError) -> Self {
             PublishError::MessageEncoding(err)
         }
     }
+    #[doc(hidden)]
     impl From<io::Error> for PublishError {
         fn from(err: io::Error) -> Self {
             PublishError::IoError(err)
         }
     }
+    #[doc(hidden)]
     impl From<mpsc::RecvError> for HandleError {
         fn from(_: mpsc::RecvError) -> Self {
             HandleError::ProviderIssue
         }
     }
+    #[doc(hidden)]
     impl From<io::Error> for DecodeError {
         fn from(err: io::Error) -> Self {
             DecodeError::IoError(err)
         }
     }
+    #[doc(hidden)]
     impl From<io::Error> for EncodeError {
         fn from(err: io::Error) -> Self {
             EncodeError::IoError(err)

--- a/lcm/src/lcm/mod.rs
+++ b/lcm/src/lcm/mod.rs
@@ -43,7 +43,7 @@ impl<'a> Lcm<'a> {
     /// This uses the `LCM_DEFAULT_URL` environment variable to construct a
     /// provider. If the variable does not exist or is empty, it will use the
     /// LCM default of "udpm://239.255.76.67:7667?ttl=0".
-    pub fn new() -> Result<Self, LcmInitError> {
+    pub fn new() -> Result<Self, InitError> {
         let lcm_default_url = env::var("LCM_DEFAULT_URL");
         let lcm_url = match lcm_default_url {
             Ok(ref s) if s.is_empty() => {
@@ -65,7 +65,7 @@ impl<'a> Lcm<'a> {
 
     /// Create a new `Lcm` instance with the provider constructed from the
     /// supplied LCM URL.
-    pub fn with_lcm_url(lcm_url: &str) -> Result<Self, LcmInitError> {
+    pub fn with_lcm_url(lcm_url: &str) -> Result<Self, InitError> {
         debug!("Creating LCM instance using \"{}\"", lcm_url);
         let (provider_name, network, options) = parse_lcm_url(lcm_url)?;
 
@@ -76,7 +76,7 @@ impl<'a> Lcm<'a> {
             #[cfg(feature = "file")]
             "file" => Provider::File(FileProvider::new(network, options)?),
 
-            _ => return Err(LcmInitError::UnknownProvider(provider_name.into())),
+            _ => return Err(InitError::UnknownProvider(provider_name.into())),
         };
 
         Ok(Lcm { provider })
@@ -145,13 +145,13 @@ pub enum Provider<'a> {
 }
 
 /// Parses the string into its LCM URL components.
-fn parse_lcm_url(lcm_url: &str) -> Result<(&str, &str, HashMap<&str, &str>), LcmInitError> {
+fn parse_lcm_url(lcm_url: &str) -> Result<(&str, &str, HashMap<&str, &str>), InitError> {
     // Start by parsing the provider string
     let (provider, remaining) = if let Some(p) = lcm_url.find("://") {
         let (p, r) = lcm_url.split_at(p);
         (p, &r[3..])
     } else {
-        return Err(LcmInitError::InvalidLcmUrl);
+        return Err(InitError::InvalidLcmUrl);
     };
 
     // Then split the network string from the options.
@@ -172,7 +172,7 @@ fn parse_lcm_url(lcm_url: &str) -> Result<(&str, &str, HashMap<&str, &str>), Lcm
                     let (a, v) = s.split_at(p);
                     Ok((a, &v[1..]))
                 } else {
-                    Err(LcmInitError::InvalidLcmUrl)
+                    Err(InitError::InvalidLcmUrl)
                 }
             })
             .collect::<Result<_, _>>()?,

--- a/lcm/src/lcm/providers/udpm.rs
+++ b/lcm/src/lcm/providers/udpm.rs
@@ -15,7 +15,7 @@ use utils::spsc;
 /// Message used to subscribe to a new channel.
 type SubscribeMsg = (
     Regex,
-    Box<Fn(&[u8]) -> Result<(), DecodeError> + Send + 'static>,
+    Box<Fn(&[u8]) -> Result<(), TrampolineError> + Send + 'static>,
 );
 
 /// LCM's magic number for short messages.
@@ -71,14 +71,14 @@ pub struct UdpmProvider<'a> {
 }
 impl<'a> UdpmProvider<'a> {
     /// Creates a new UDPM provider using the given settings.
-    pub fn new(network: &str, options: HashMap<&str, &str>) -> Result<Self, LcmInitError> {
+    pub fn new(network: &str, options: HashMap<&str, &str>) -> Result<Self, InitError> {
         // Parse the network string into the address and port
         let (addr, port) = UdpmProvider::parse_network_string(network)?;
 
         // Get the TTL value
         let ttl = match options.get("ttl").unwrap_or(&"0").parse() {
             Ok(ttl) => ttl,
-            Err(_) => return Err(LcmInitError::InvalidLcmUrl),
+            Err(_) => return Err(InitError::InvalidLcmUrl),
         };
 
         debug!(
@@ -130,13 +130,13 @@ impl<'a> UdpmProvider<'a> {
 
         // Then create the function that will convert the bytes into a message
         // and send it and the function that will pass things on to the callback.
-        let conversion_func = move |mut bytes: &[u8]| -> Result<(), DecodeError> {
+        let conversion_func = move |mut bytes: &[u8]| -> Result<(), TrampolineError> {
             // First try to decode the message
             let message = M::decode_with_hash(&mut bytes)?;
 
             // Then double check that the channel isn't closed
             if tx.is_closed() {
-                return Err(DecodeError::MessageChannelClosed);
+                return Err(TrampolineError::MessageChannelClosed);
             }
 
             // Otherwise, but it in the queue and call it a day.
@@ -165,7 +165,10 @@ impl<'a> UdpmProvider<'a> {
         // Send it across the way and then store our callback.
         match self.subscribe_tx.send((channel, Box::new(conversion_func))) {
             Ok(_) => {}
-            Err(_) => return Err(SubscribeError::MissingProvider),
+            Err(_) => {
+                warn!("UDPM provider has died. Unable to send subscribe message.");
+                return Err(SubscribeError::ProviderIssue)
+            },
         }
         self.subscriptions
             .push((Subscription(sub_id), Box::new(callback_fn)));
@@ -194,11 +197,13 @@ impl<'a> UdpmProvider<'a> {
         let message_buf = message.encode_with_hash()?;
 
         if channel.len() > MAX_CHANNEL_NAME_LENGTH {
-            return Err(PublishError::ChannelNameTooLong);
+            warn!("The channel name was too long. Unable to publish message.");
+            return Err(PublishError::ProviderIssue);
         }
 
         if message_buf.len() > MAX_MESSAGE_SIZE {
-            return Err(PublishError::MessageTooLarge);
+            warn!("The message was too large to publish.");
+            return Err(PublishError::ProviderIssue);
         }
 
         // Determine if we need to split this message up into fragments
@@ -235,7 +240,8 @@ impl<'a> UdpmProvider<'a> {
     pub fn handle_timeout(&mut self, timeout: Duration) -> Result<(), HandleError> {
         debug!("Waiting on notify channel");
         if let Err(mpsc::RecvTimeoutError::Disconnected) = self.notify_rx.recv_timeout(timeout) {
-            return Err(HandleError::MissingProvider);
+            warn!("The provider has been shut down or otherwise killed.");
+            return Err(HandleError::ProviderIssue);
         }
         self.subscriptions
             .iter_mut()
@@ -245,7 +251,7 @@ impl<'a> UdpmProvider<'a> {
     }
 
     /// Parse the network string into the address and port components.
-    fn parse_network_string(network: &str) -> Result<(Ipv4Addr, u16), LcmInitError> {
+    fn parse_network_string(network: &str) -> Result<(Ipv4Addr, u16), InitError> {
         // We can't just parse this, since we need to provide default values.
         let (addr, port) = match network.find(':') {
             Some(p) => {
@@ -272,11 +278,11 @@ impl<'a> UdpmProvider<'a> {
         // Parse them into their respective types
         let addr = match addr.parse() {
             Ok(a) => a,
-            Err(_) => return Err(LcmInitError::InvalidLcmUrl),
+            Err(_) => return Err(InitError::InvalidLcmUrl),
         };
         let port = match port.parse() {
             Ok(p) => p,
-            Err(_) => return Err(LcmInitError::InvalidLcmUrl),
+            Err(_) => return Err(InitError::InvalidLcmUrl),
         };
 
         Ok((addr, port))
@@ -333,7 +339,8 @@ impl<'a> UdpmProvider<'a> {
 
         if n_fragments > ::std::u16::MAX as usize {
             // Probably a redundant check
-            return Err(PublishError::MessageTooLarge);
+            warn!("The message was broken into too many fragments. Unable to send.");
+            return Err(PublishError::ProviderIssue);
         }
 
         trace!(
@@ -379,7 +386,8 @@ impl<'a> UdpmProvider<'a> {
             let sent = self.socket.send_to(&buf[0..datagram_size], self.addr)?;
 
             if sent != datagram_size {
-                return Err(PublishError::MessageNotSent);
+                warn!("The number of bytes sent ({}) did not equal the size of the datagram ({}).", sent, datagram_size);
+                return Err(PublishError::ProviderIssue);
             }
 
             remaining_message = &remaining_message[amount_written..];
@@ -423,7 +431,8 @@ impl<'a> UdpmProvider<'a> {
         let sent = self.socket.send_to(&buf[0..datagram_size], self.addr)?;
 
         if sent != datagram_size {
-            Err(PublishError::MessageNotSent)
+            warn!("The number of bytes sent ({}) did not equal the size of the datagram ({}).", sent, datagram_size);
+            Err(PublishError::ProviderIssue)
         } else {
             Ok(())
         }
@@ -452,7 +461,7 @@ pub struct Backend {
 }
 impl Backend {
     /// Create a `Backend` with the specified channels.
-    pub fn new(
+    fn new(
         socket: UdpSocket,
         notify_tx: mpsc::SyncSender<()>,
         subscribe_rx: mpsc::Receiver<SubscribeMsg>,
@@ -472,7 +481,7 @@ impl Backend {
     /// through the appropriate channels based on subscriptions. It will only
     /// exit if the notification channel closes (which signifies that the
     /// client provider object has been deleted).
-    pub fn run(mut self) -> io::Result<()> {
+    fn run(mut self) -> io::Result<()> {
         let mut buf = [0u8; 65535];
 
         loop {
@@ -658,7 +667,7 @@ impl Backend {
             if re.is_match(channel) {
                 trace!("Channel \"{}\" matched subscription \"{}\"", channel, re);
                 match (*f)(message) {
-                    Err(DecodeError::MessageChannelClosed) => false,
+                    Err(TrampolineError::MessageChannelClosed) => false,
                     Err(e) => {
                         warn!("Error decoding message: {}", e);
                         true
@@ -708,4 +717,23 @@ struct FragmentBuffer {
 
     /// The received parts of the message.
     buffer: Vec<u8>,
+}
+
+/// Errors that can happen during the trampoline closure.
+#[derive(Debug, Fail)]
+enum TrampolineError {
+    /// The channel was closed.
+    ///
+    /// This generally signifies that the user unsubscribed from the channel.
+    #[fail(display = "Unsubscribed from the channel")]
+    MessageChannelClosed,
+
+    /// There was a decoding error.
+    #[fail(display = "Unable to decode message: {}", _0)]
+    Decode(#[cause] DecodeError),
+}
+impl From<DecodeError> for TrampolineError {
+    fn from(err: DecodeError) -> Self {
+        TrampolineError::Decode(err)
+    }
 }

--- a/lcm/src/message.rs
+++ b/lcm/src/message.rs
@@ -35,7 +35,7 @@ pub trait Message: Marshall {
     fn decode_with_hash(mut buffer: &mut Read) -> Result<Self, DecodeError> {
         let hash: u64 = Marshall::decode(&mut buffer)?;
         if hash != Self::HASH {
-            return Err(DecodeError::hash_mismatch(Self::HASH, hash));
+            return Err(DecodeError::HashMismatch { expected: Self::HASH, found: hash});
         }
         Marshall::decode(buffer)
     }
@@ -83,7 +83,7 @@ impl Marshall for bool {
         match value {
             0 => Ok(false),
             1 => Ok(true),
-            v @ _ => Err(DecodeError::invalid_bool(v)),
+            v @ _ => Err(DecodeError::InvalidBoolean(v)),
         }
     }
 
@@ -109,14 +109,14 @@ impl Marshall for String {
 
         let len = i32::decode(buffer)?;
         if len <= 0 {
-            return Err(DecodeError::invalid_size(len as i64));
+            return Err(DecodeError::InvalidSize(len as i64));
         }
         let len = len - 1;
         let mut buf = Vec::new();
         for _ in 0..len {
             buf.push(u8::decode(buffer)?);
         }
-        let result = String::from_utf8(buf).map_err(|e| DecodeError::invalid_utf8(e))?;
+        let result = String::from_utf8(buf).map_err(|e| DecodeError::Utf8Error(e))?;
         match buffer.read_u8() {
             Ok(0) => Ok(result),
             Ok(_) => Err(DecodeError::MissingNullTerminator),


### PR DESCRIPTION
This solves the error mess in three ways:
1. There is now an `Error` type that has variants for the four major error types. Any situation where the user wants to return errors from any combination of LCM operations can just return this type. If the user wants to try and recover from the error, they still have enough information to make this possible.
2. Provider specific errors have been conglomerated into `ProviderIssue` variants. At some point, I want these to include a `#[cause]` of some sort but I'm not sure what way is best. See followup comments for more info.
3. The `impl From<T>` items are hidden from docs. This isn't perfect but I am of the opinion that undocumented things can be changed without being considered breaking, so this is fine for now. Again, see followup comments for more info.
