### PR TITLE
Allow additional derived traits to be specified

### DIFF
--- a/lcm-gen/Cargo.toml
+++ b/lcm-gen/Cargo.toml
@@ -18,6 +18,8 @@ heck = "0.3.0"
 
 [dev-dependencies]
 pretty_assertions = "0.5.0"
+assert_cli = "0.5.4"
+tempdir = "0.3.6"
 
 [features]
 default = ["cli"]

--- a/lcm-gen/src/codegen.rs
+++ b/lcm-gen/src/codegen.rs
@@ -81,7 +81,7 @@ impl<'a> CodeGenerator<'a> {
         if let Some(ref comment) = s.comment {
             self.generate_comment(comment);
         }
-        self.push_line("#[derive(Debug, Message)]");
+        self.push_line("#[derive(Clone, Debug, Message)]");
         self.push_line(&format!("pub struct {} {{", struct_name));
         for field in &s.fields {
             self.indent().generate_field(field);

--- a/lcm-gen/src/lcm-gen.rs
+++ b/lcm-gen/src/lcm-gen.rs
@@ -8,6 +8,10 @@ use failure::Error;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+/// LCM code generator for Rust.
+///
+/// Note that the lcm-gen crate can also be added as a build
+/// dependency to your project, to generate code at build time.
 #[derive(Debug, StructOpt)]
 #[structopt(raw(setting = "structopt::clap::AppSettings::ColoredHelp"))]
 struct Options {
@@ -51,6 +55,7 @@ fn run() -> Result<(), Error> {
     let mut config = lcm_gen::Config {
         package_prefix: options.package_prefix,
         output_file: Some(options.output_file),
+        additional_traits: options.custom_derives,
     };
     config.generate(&options.input_files)
 }

--- a/lcm-gen/src/lib.rs
+++ b/lcm-gen/src/lib.rs
@@ -38,6 +38,7 @@ pub fn generate<P: AsRef<Path> + Debug>(lcm_files: &[P]) -> Result<(), Error> {
 pub struct Config {
     pub package_prefix: Option<String>,
     pub output_file: Option<PathBuf>,
+    pub additional_traits: Vec<String>,
 }
 
 impl Default for Config {
@@ -45,6 +46,7 @@ impl Default for Config {
         Config {
             package_prefix: None,
             output_file: None,
+            additional_traits: vec![],
         }
     }
 }
@@ -102,6 +104,6 @@ impl Config {
             }
         }
 
-        Ok(codegen::generate(&root_module))
+        Ok(codegen::generate_with_config(&root_module, self))
     }
 }

--- a/lcm-gen/tests/cli.rs
+++ b/lcm-gen/tests/cli.rs
@@ -1,0 +1,87 @@
+extern crate assert_cli;
+#[macro_use]
+extern crate pretty_assertions;
+extern crate tempdir;
+
+use std::fs::File;
+use std::io::Read;
+use tempdir::TempDir;
+
+#[test]
+fn creates_output() {
+    let dir = TempDir::new("lcm-gen").unwrap();
+    let output = dir.path().join("mod.rs");
+    let output = output.to_str().unwrap();
+    let input = "tests/data/temperature_t.lcm";
+
+    assert_cli::Assert::command(&["../target/debug/lcm-gen-rust", "--out", output, input])
+        .stdout()
+        .is("")
+        .unwrap();
+
+    let mut output = File::open(output).unwrap();
+    let mut generated = String::new();
+    output.read_to_string(&mut generated).unwrap();
+    assert!(generated.contains("struct Temperature"));
+}
+
+#[test]
+fn package_prefix() {
+    let dir = TempDir::new("lcm-gen").unwrap();
+    let output = dir.path().join("mod.rs");
+    let output = output.to_str().unwrap();
+    let input = "tests/data/temperature_t.lcm";
+
+    assert_cli::Assert::command(&[
+        "../target/debug/lcm-gen-rust",
+        "--out",
+        output,
+        "--package-prefix",
+        "foo.bar",
+        input,
+    ]).stdout()
+        .is("")
+        .unwrap();
+
+    let mut output = File::open(output).unwrap();
+    let mut generated = String::new();
+    output.read_to_string(&mut generated).unwrap();
+    assert!(generated.contains("mod foo"));
+    assert!(generated.contains("mod bar"));
+
+    let mod_lines:Vec<_> = generated.lines().filter(|l| l.contains("mod")).collect();
+    assert_eq!(mod_lines, ["pub mod foo {", "    pub mod bar {"]);
+}
+
+#[test]
+fn custom_derives() {
+    let dir = TempDir::new("lcm-gen").unwrap();
+    let output = dir.path().join("mod.rs");
+    let output = output.to_str().unwrap();
+    let input = "tests/data/temperature_t.lcm";
+
+    assert_cli::Assert::command(&[
+        "../target/debug/lcm-gen-rust",
+        "--out",
+        output,
+        "--derive",
+        "Serialize",
+        "--derive",
+        "Deserialize",
+        input,
+    ]).stdout()
+        .is("")
+        .unwrap();
+
+    let mut output = File::open(output).unwrap();
+    let mut generated = String::new();
+    output.read_to_string(&mut generated).unwrap();
+    let derives = generated
+        .lines()
+        .find(|l| l.contains("derive"))
+        .expect("no derives found");
+    assert_eq!(
+        derives,
+        "#[derive(Clone, Debug, Deserialize, Message, Serialize)]"
+    );
+}

--- a/lcm-gen/tests/codegen.rs
+++ b/lcm-gen/tests/codegen.rs
@@ -28,7 +28,7 @@ fn simple_struct() {
 
     let generated = codegen::generate(&module);
 
-    let expected = r#"#[derive(Debug, Message)]
+    let expected = r#"#[derive(Clone, Debug, Message)]
 pub struct MyType {
     pub field: f64,
 }
@@ -53,7 +53,7 @@ macro_rules! check_generated {
 check_generated!(
     camera_image_t,
     r#"pub mod mycorp {
-    #[derive(Debug, Message)]
+    #[derive(Clone, Debug, Message)]
     pub struct CameraImage {
         pub utime: i64,
         pub camera_name: String,
@@ -68,7 +68,7 @@ check_generated!(
     comments_t,
     r##"#[doc = r#" This is a comment
  that spans multiple lines"#]
-#[derive(Debug, Message)]
+#[derive(Clone, Debug, Message)]
 pub struct MyStruct {
     #[doc = r#" Horizontal position in meters."#]
     pub x: i32,
@@ -80,16 +80,16 @@ pub struct MyStruct {
 
 check_generated!(
     multiple_structs,
-    r#"#[derive(Debug, Message)]
+    r#"#[derive(Clone, Debug, Message)]
 pub struct A {
     pub b: B,
     pub c: C,
 }
-#[derive(Debug, Message)]
+#[derive(Clone, Debug, Message)]
 pub struct B {
     pub a: A,
 }
-#[derive(Debug, Message)]
+#[derive(Clone, Debug, Message)]
 pub struct C {
     pub b: B,
 }
@@ -98,7 +98,7 @@ pub struct C {
 
 check_generated!(
     my_constants_t,
-    r##"#[derive(Debug, Message)]
+    r##"#[derive(Clone, Debug, Message)]
 pub struct MyConstants {
 }
 impl MyConstants {
@@ -112,7 +112,7 @@ impl MyConstants {
 
 check_generated!(
     point2d_list_t,
-    r#"#[derive(Debug, Message)]
+    r#"#[derive(Clone, Debug, Message)]
 pub struct Point2dList {
     pub npoints: i32,
     #[lcm(length = "npoints")]
@@ -123,7 +123,7 @@ pub struct Point2dList {
 
 check_generated!(
     temperature_t,
-    r##"#[derive(Debug, Message)]
+    r##"#[derive(Clone, Debug, Message)]
 pub struct Temperature {
     pub utime: i64,
     #[doc = r#" Temperature in degrees Celsius. A "float" would probably
@@ -143,7 +143,7 @@ pub struct Temperature {
 /// ```
 check_generated!(
     member_group,
-    r##"#[derive(Debug, Message)]
+    r##"#[derive(Clone, Debug, Message)]
 pub struct MemberGroup {
     #[doc = r#" A vector."#]
     pub x: f64,

--- a/lcm-gen/tests/codegen.rs
+++ b/lcm-gen/tests/codegen.rs
@@ -2,7 +2,7 @@ extern crate lcm_gen;
 #[macro_use]
 extern crate pretty_assertions;
 
-use lcm_gen::{ast, codegen};
+use lcm_gen::{ast, codegen, Config};
 use std::collections::HashMap;
 
 #[test]
@@ -154,3 +154,31 @@ pub struct MemberGroup {
 }
 "##
 );
+
+#[test]
+fn optional_traits() {
+    let module = ast::Module {
+        submodules: HashMap::new(),
+        structs: vec![
+            ast::Struct {
+                comment: None,
+                name: "MyType".into(),
+                fields: vec![],
+                constants: vec![],
+            },
+        ],
+    };
+
+    let config = Config {
+        additional_traits: vec!["Serialize".into(), "Deserialize".into(), "PartialEq".into()],
+        ..Config::default()
+    };
+    let generated = codegen::generate_with_config(&module, &config);
+
+    let expected = r#"#[derive(Clone, Debug, Deserialize, Message, PartialEq, Serialize)]
+pub struct MyType {
+}
+"#;
+
+    assert_eq!(generated, expected);
+}


### PR DESCRIPTION
See #29 

This creates a slightly odd pattern in which the `Config` struct invokes the `codegen` module and passes a reference to itself. I'm okay with it for now.

It also adds some CLI tests.