### PR TITLE
Fix doc warnings in lcm crate.

### DIFF
--- a/lcm/src/lcm/mod.rs
+++ b/lcm/src/lcm/mod.rs
@@ -87,7 +87,7 @@ impl<'a> Lcm<'a> {
     ///
     /// The input is interpreted as a regular expression. Unlike the C
     /// implementation of LCM, the expression is *not* implicitly surrounded
-    /// by '^' and '$'.
+    /// by `^` and `$`.
     pub fn subscribe<M, F>(
         &mut self,
         channel: &str,

--- a/lcm/src/lib.rs
+++ b/lcm/src/lib.rs
@@ -1,6 +1,6 @@
 //! From the [LCM Homepage](http://lcm-proj.github.io/):
-//! >
-//! LCM is a set of libraries and tools for message passing and data marshalling,
+//!
+//! > LCM is a set of libraries and tools for message passing and data marshalling,
 //! targeted at real-time systems where high-bandwidth and low latency are critical.
 //! It provides a publish/subscribe message passing model
 //! and automatic marshalling/unmarshalling code generation


### PR DESCRIPTION
Addresses #34 

There are still some warnings in the docs for the test crate, but they actually stem from the comments in the code generated from the .lcm files. I'm not interested in having `lcm-gen` parse comments for markdown issues, and the `tests` crate will never be published, so I think we can just live with that warning.