### PR TITLE
Fix bugs in UDPM

### DIFF
--- a/lcm/src/utils/spsc.rs
+++ b/lcm/src/utils/spsc.rs
@@ -273,7 +273,7 @@ impl<T> RingBuffer<T> {
         let conv_offset = (offset % self.capacity) as isize;
         debug_assert!(conv_offset >= 0, "converted offset does not fit in usize");
         unsafe {
-            *self.data.offset(conv_offset) = item;
+            ptr::write(self.data.offset(conv_offset), item);
         }
     }
 


### PR DESCRIPTION
There were three bugs fixed here.

1. The SPSC would attempt to drop uninitialized values. This was because
   I was writing to the pointer like I would a reference instead of
   using `ptr::write`.
2. The UDPM backend was dropping messages larger than the maximum
   desired outgoing datagram size instead of the messages that were
   larger than the maximum message size.
3. The fragment headers are now written correctly. The fragment count
   and the number of fragments were being written as `u32` instead of
   `u16`.