### PR TITLE
Use url crate instead of parsing it ourselves.

### DIFF
--- a/lcm/Cargo.toml
+++ b/lcm/Cargo.toml
@@ -10,6 +10,7 @@ byteorder = "1.2.1"
 failure = "0.1"
 regex = "0.2"
 lcm-derive = { path = "../lcm-derive" }
+url = "1.7.0"
 
 [features]
 default = ["udpm"]

--- a/lcm/src/error.rs
+++ b/lcm/src/error.rs
@@ -5,8 +5,9 @@
 //! operator or `From`. The other error types exist in case one wants to
 //! attempt to recover from an error.
 
-use std::{io, string};
+use std::{io, num, string};
 use regex;
+use url;
 
 // TODO:
 // We should hide the `From<T>` implementations for all of these errors. Most
@@ -93,7 +94,10 @@ pub enum InitError {
 
     /// The provided LCM URL was not valid.
     #[fail(display = "Invalid LCM URL.")]
-    InvalidLcmUrl,
+    InvalidLcmUrl(#[cause] url::ParseError),
+
+    #[fail(display = "Failed to parse time to live argument.")]
+    InvalidTtl(#[cause] num::ParseIntError),
 }
 
 /// The attempt to subscribe to a channel was unsuccessful.
@@ -221,6 +225,12 @@ pub mod from {
     impl From<io::Error> for InitError {
         fn from(err: io::Error) -> Self {
             InitError::IoError(err)
+        }
+    }
+    #[doc(hidden)]
+    impl From<url::ParseError> for InitError {
+        fn from(err: url::ParseError) -> Self {
+            InitError::InvalidLcmUrl(err)
         }
     }
     #[doc(hidden)]

--- a/lcm/src/lib.rs
+++ b/lcm/src/lib.rs
@@ -25,6 +25,7 @@ extern crate byteorder;
 extern crate failure;
 extern crate net2;
 extern crate regex;
+extern crate url;
 
 mod utils;
 


### PR DESCRIPTION
This removes the custom URL parsing and replaces it with the `url` crate. It simplifies the code and should result in slightly better error messages in the case of an invalid provider address.

This will also successfully parse an IPv6 address, but it'll panic with an unimplemented message. I have no idea whether LCM supports IPv6. It wouldn't be too hard to support it here - there are just a few function calls that have v4 an v6 variants.