### PR TITLE
Raise minimum version of Pest.

### DIFF
--- a/lcm-gen/Cargo.toml
+++ b/lcm-gen/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/lcm-gen.rs"
 required-features = ["cli"]
 
 [dependencies]
-pest = "1.0.3"
-pest_derive = "1.0.3"
+pest = "1.0.6"
+pest_derive = "1.0.7"
 failure = "0.1.1"
 structopt = { version = "0.2.1", optional = true }
 itertools = "0.7.6"


### PR DESCRIPTION
My local Cargo.lock was using 1.0.3, which caused lcm-gen to fail to compile. Travis was building with 1.0.6 (1.0.7 for pest-derive), so this didn't show up in CI.